### PR TITLE
create: 누락된 changelog 생성

### DIFF
--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/controller/ArticleController.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/controller/ArticleController.kt
@@ -1,5 +1,6 @@
 package com.arabyte.arabyteapi.domain.article.controller
 
+import com.arabyte.arabyteapi.domain.article.dto.*
 import com.arabyte.arabyteapi.domain.article.dto.article.*
 import com.arabyte.arabyteapi.domain.article.enums.ArticleKind
 import com.arabyte.arabyteapi.domain.article.service.ArticleService

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/controller/ArticleLikeController.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/controller/ArticleLikeController.kt
@@ -1,7 +1,7 @@
 package com.arabyte.arabyteapi.domain.article.controller
 
-import com.arabyte.arabyteapi.domain.article.dto.article.ArticleLikeRequest
-import com.arabyte.arabyteapi.domain.article.dto.article.ArticleLikeResponse
+import com.arabyte.arabyteapi.domain.article.dto.ArticleLikeRequest
+import com.arabyte.arabyteapi.domain.article.dto.ArticleLikeResponse
 import com.arabyte.arabyteapi.domain.article.service.ArticleLikeService
 import com.arabyte.arabyteapi.global.annotation.SwaggerCustomException
 import com.arabyte.arabyteapi.global.enums.CustomExceptionGroup

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/ArticleLikeRequest.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/ArticleLikeRequest.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.article
+package com.arabyte.arabyteapi.domain.article.dto
 
 data class ArticleLikeRequest(
     val articleId: Long,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/ArticleLikeResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/ArticleLikeResponse.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.article
+package com.arabyte.arabyteapi.domain.article.dto
 
 data class ArticleLikeResponse(
     val liked: Boolean,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/ArticlePreviewResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/ArticlePreviewResponse.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.article
+package com.arabyte.arabyteapi.domain.article.dto
 
 import com.arabyte.arabyteapi.domain.article.enums.ArticleKind
 

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/ArticleResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/ArticleResponse.kt
@@ -1,6 +1,6 @@
-package com.arabyte.arabyteapi.domain.article.dto.article
+package com.arabyte.arabyteapi.domain.article.dto
 
-import com.arabyte.arabyteapi.domain.article.dto.comment.CommentResponse
+import com.arabyte.arabyteapi.domain.comment.dto.CommentResponse
 
 data class ArticleResponse(
     val articleId: Long,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/CreateArticleRequest.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/CreateArticleRequest.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.article
+package com.arabyte.arabyteapi.domain.article.dto
 
 import com.arabyte.arabyteapi.domain.article.enums.ArticleKind
 

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/CreateArticleResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/CreateArticleResponse.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.article
+package com.arabyte.arabyteapi.domain.article.dto
 
 data class CreateArticleResponse(
     val articleId: Long,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/DeleteArticleResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/DeleteArticleResponse.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.article
+package com.arabyte.arabyteapi.domain.article.dto
 
 data class DeleteArticleResponse(
     val articleId: Long,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/UpdateArticleRequest.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/UpdateArticleRequest.kt
@@ -1,0 +1,10 @@
+package com.arabyte.arabyteapi.domain.article.dto
+
+import com.arabyte.arabyteapi.domain.article.enums.ArticleKind
+
+data class UpdateArticleRequest(
+    val title: String,
+    val text: String,
+    val isAnonymous: Boolean,
+    val articleKind: ArticleKind
+)

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/UpdateArticleResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/UpdateArticleResponse.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.article
+package com.arabyte.arabyteapi.domain.article.dto
 
 data class UpdateArticleResponse(
     val articleId: Long,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/article/UpdateArticleRequest.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/dto/article/UpdateArticleRequest.kt
@@ -1,7 +1,0 @@
-package com.arabyte.arabyteapi.domain.article.dto.article
-
-data class UpdateArticleRequest(
-    val title: String,
-    val text: String,
-    val isAnonymous: Boolean
-)

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/entity/Article.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/entity/Article.kt
@@ -1,6 +1,7 @@
 package com.arabyte.arabyteapi.domain.article.entity
 
 import com.arabyte.arabyteapi.domain.article.enums.ArticleKind
+import com.arabyte.arabyteapi.domain.comment.entity.Comment
 import com.arabyte.arabyteapi.domain.user.entity.User
 import com.arabyte.arabyteapi.global.entity.BaseEntity
 import jakarta.persistence.*
@@ -17,7 +18,7 @@ class Article(
     val user: User,
 
     @Enumerated
-    val articleKindId: ArticleKind
+    var articleKindId: ArticleKind
 ) : BaseEntity() {
 
     @OneToMany(mappedBy = "article", cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/service/ArticleLikeService.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/service/ArticleLikeService.kt
@@ -1,7 +1,7 @@
 package com.arabyte.arabyteapi.domain.article.service
 
-import com.arabyte.arabyteapi.domain.article.dto.article.ArticleLikeRequest
-import com.arabyte.arabyteapi.domain.article.dto.article.ArticleLikeResponse
+import com.arabyte.arabyteapi.domain.article.dto.ArticleLikeRequest
+import com.arabyte.arabyteapi.domain.article.dto.ArticleLikeResponse
 import com.arabyte.arabyteapi.domain.article.entity.ArticleLike
 import com.arabyte.arabyteapi.domain.article.repository.ArticleLikeRepository
 import com.arabyte.arabyteapi.domain.user.service.UserService

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/article/service/ArticleService.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/article/service/ArticleService.kt
@@ -1,11 +1,12 @@
 package com.arabyte.arabyteapi.domain.article.service
 
+import com.arabyte.arabyteapi.domain.article.dto.*
 import com.arabyte.arabyteapi.domain.article.dto.article.*
-import com.arabyte.arabyteapi.domain.article.dto.comment.CommentResponse
+import com.arabyte.arabyteapi.domain.comment.dto.CommentResponse
 import com.arabyte.arabyteapi.domain.article.entity.Article
 import com.arabyte.arabyteapi.domain.article.enums.ArticleKind
 import com.arabyte.arabyteapi.domain.article.repository.ArticleRepository
-import com.arabyte.arabyteapi.domain.article.repository.CommentRepository
+import com.arabyte.arabyteapi.domain.comment.repository.CommentRepository
 import com.arabyte.arabyteapi.domain.user.service.UserService
 import com.arabyte.arabyteapi.global.enums.CustomError
 import com.arabyte.arabyteapi.global.exception.CustomException
@@ -122,6 +123,7 @@ class ArticleService(
         article.title = request.title
         article.text = request.text
         article.isAnonymous = request.isAnonymous
+        article.articleKindId = request.articleKind
 
         articleRepository.save(article)
 

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/controller/CommentController.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/controller/CommentController.kt
@@ -1,7 +1,7 @@
-package com.arabyte.arabyteapi.domain.article.controller
+package com.arabyte.arabyteapi.domain.comment.controller
 
-import com.arabyte.arabyteapi.domain.article.dto.comment.*
-import com.arabyte.arabyteapi.domain.article.service.CommentService
+import com.arabyte.arabyteapi.domain.comment.service.CommentService
+import com.arabyte.arabyteapi.domain.comment.dto.*
 import com.arabyte.arabyteapi.global.annotation.SwaggerCustomException
 import com.arabyte.arabyteapi.global.enums.CustomExceptionGroup
 import io.swagger.v3.oas.annotations.Operation

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/CommentResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/CommentResponse.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.comment
+package com.arabyte.arabyteapi.domain.comment.dto
 
 data class CommentResponse(
     val commentId: Long,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/CreateCommentRequest.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/CreateCommentRequest.kt
@@ -1,9 +1,9 @@
-package com.arabyte.arabyteapi.domain.article.dto.comment
+package com.arabyte.arabyteapi.domain.comment.dto
 
 data class CreateCommentRequest(
     val articleId: Long,
     val userId: Long,
     val text: String,
-    val parentId: Long? = null,
+    val parentId: Long?,
     val isAnonymous: Boolean
 )

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/CreateCommentResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/CreateCommentResponse.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.comment
+package com.arabyte.arabyteapi.domain.comment.dto
 
 data class CreateCommentResponse(
     val commentId: Long,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/DeleteCommentResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/DeleteCommentResponse.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.comment
+package com.arabyte.arabyteapi.domain.comment.dto
 
 data class DeleteCommentResponse(
     val commentId: Long,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/UpdateCommentRequest.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/UpdateCommentRequest.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.comment
+package com.arabyte.arabyteapi.domain.comment.dto
 
 data class UpdateCommentRequest(
     val text: String,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/UpdateCommentResponse.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/dto/UpdateCommentResponse.kt
@@ -1,4 +1,4 @@
-package com.arabyte.arabyteapi.domain.article.dto.comment
+package com.arabyte.arabyteapi.domain.comment.dto
 
 data class UpdateCommentResponse(
     val commentId: Long,

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/entity/Comment.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/entity/Comment.kt
@@ -1,5 +1,6 @@
-package com.arabyte.arabyteapi.domain.article.entity
+package com.arabyte.arabyteapi.domain.comment.entity
 
+import com.arabyte.arabyteapi.domain.article.entity.Article
 import com.arabyte.arabyteapi.domain.user.entity.User
 import com.arabyte.arabyteapi.global.entity.BaseEntity
 import jakarta.persistence.*

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/repository/CommentRepository.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/repository/CommentRepository.kt
@@ -1,6 +1,6 @@
-package com.arabyte.arabyteapi.domain.article.repository
+package com.arabyte.arabyteapi.domain.comment.repository
 
-import com.arabyte.arabyteapi.domain.article.entity.Comment
+import com.arabyte.arabyteapi.domain.comment.entity.Comment
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/service/CommentService.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/comment/service/CommentService.kt
@@ -1,8 +1,9 @@
-package com.arabyte.arabyteapi.domain.article.service
+package com.arabyte.arabyteapi.domain.comment.service
 
-import com.arabyte.arabyteapi.domain.article.dto.comment.*
-import com.arabyte.arabyteapi.domain.article.entity.Comment
-import com.arabyte.arabyteapi.domain.article.repository.CommentRepository
+import com.arabyte.arabyteapi.domain.article.service.ArticleService
+import com.arabyte.arabyteapi.domain.comment.entity.Comment
+import com.arabyte.arabyteapi.domain.comment.repository.CommentRepository
+import com.arabyte.arabyteapi.domain.comment.dto.*
 import com.arabyte.arabyteapi.domain.user.service.UserService
 import com.arabyte.arabyteapi.global.enums.CustomError
 import com.arabyte.arabyteapi.global.exception.CustomException

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/user/entity/User.kt
@@ -2,7 +2,7 @@ package com.arabyte.arabyteapi.domain.user.entity
 
 import com.arabyte.arabyteapi.domain.article.entity.Article
 import com.arabyte.arabyteapi.domain.article.entity.ArticleLike
-import com.arabyte.arabyteapi.domain.article.entity.Comment
+import com.arabyte.arabyteapi.domain.comment.entity.Comment
 import com.arabyte.arabyteapi.domain.location.entity.Location
 import com.arabyte.arabyteapi.global.entity.BaseEntity
 import jakarta.persistence.*

--- a/src/main/resources/db/changelog/2025/04/16-02-changelog.xml
+++ b/src/main/resources/db/changelog/2025/04/16-02-changelog.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.29.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1744792844575-3" author="djlim00">
+        <addColumn tableName="user">
+            <column name="location_id" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+    <changeSet id="1744792844575-4" author="djlim00">
+        <addForeignKeyConstraint baseColumnNames="location_id" baseTableName="user" constraintName="FK_USER_ON_LOCATION"
+                                 referencedColumnNames="id" referencedTableName="location"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## 📚 개요

- 누락되었던 User테이블과 location테이블 연관관계를 만드는 changelog를 생성했습니다.
- 게시글 수정 시 게시판 종류를 수정하는 로직이 제대로 동작하지 않는 문제를 해결했습니다.
- Article 도메인에 합쳐져 있던 Commnet 관련 로직을 따로 comment폴더로 분리하였습니다. 

## 🕐 리뷰 예상 시간

> 10m

## ❗❗ 중요한 변경점(Option)

- 위에 다 써져있습니다..