### PR TITLE
FIX - SecurityCofiguration 설정 오류로 인증 오류 해결

### DIFF
--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/auth/util/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/auth/util/JwtAuthenticationFilter.kt
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.User
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
@@ -19,18 +18,11 @@ class JwtAuthenticationFilter(
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        // TODO - config에서 처리
-        val uri = request.requestURI
-        if (uri.startsWith("/auth/kakao")) {
-            filterChain.doFilter(request, response)
-            return
-        }
-
         val token = jwtProvider.resolveToken(request)
 
         if (!token.isNullOrBlank() && jwtProvider.isValidToken(token)) {
             val userId = jwtProvider.getUserId(token)
-            val userDetails: UserDetails =
+            val userDetails =
                 User.withUsername(userId).password("").authorities(emptyList()).build()
             val authentication = JwtAuthenticationToken(userDetails, token, userDetails.authorities)
             authentication.details = WebAuthenticationDetailsSource().buildDetails(request)

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/auth/util/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/auth/util/JwtAuthenticationFilter.kt
@@ -3,9 +3,9 @@ package com.arabyte.arabyteapi.domain.auth.util
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.User
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
@@ -23,9 +23,13 @@ class JwtAuthenticationFilter(
         if (!token.isNullOrBlank() && jwtProvider.isValidToken(token)) {
             val userId = jwtProvider.getUserId(token)
             val userDetails =
-                User.withUsername(userId).password("").authorities(emptyList()).build()
-            val authentication = JwtAuthenticationToken(userDetails, token, userDetails.authorities)
-            authentication.details = WebAuthenticationDetailsSource().buildDetails(request)
+                User.builder()
+                    .username(userId)
+                    .password("")
+                    .authorities(emptyList())
+                    .build()
+            val authentication =
+                UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
 
             SecurityContextHolder.getContext().authentication = authentication
         }

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/auth/util/JwtProvider.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/auth/util/JwtProvider.kt
@@ -64,7 +64,7 @@ class JwtProvider(
         } catch (e: ExpiredJwtException) {
             throw CustomException(CustomError.ACCESS_TOKEN_EXPIRED)
         } catch (e: Exception) {
-            throw CustomException(CustomError.INVALID_TOKEN)
+            false
         }
     }
 

--- a/src/main/kotlin/com/arabyte/arabyteapi/global/configuration/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/global/configuration/SecurityConfiguration.kt
@@ -19,7 +19,15 @@ class SecurityConfiguration(
         http
             .csrf { it.disable() }
             .authorizeHttpRequests {
-                it.requestMatchers("/auth/kakao/").permitAll()
+                it.requestMatchers(
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**",
+                    "/auth/kakao/**",
+                    "/auth/reissue",
+                    "/error"
+                )
+                    .permitAll()
+                it.anyRequest().authenticated()
             }
             .addFilterBefore(
                 JwtAuthenticationFilter(jwtProvider),
@@ -27,6 +35,7 @@ class SecurityConfiguration(
             )
             .formLogin { it.disable() }
             .httpBasic { it.disable() }
+            .logout { it.disable() }
 
         return http.build()
     }

--- a/src/main/kotlin/com/arabyte/arabyteapi/global/configuration/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/global/configuration/SecurityConfiguration.kt
@@ -1,21 +1,30 @@
 package com.arabyte.arabyteapi.global.configuration
 
+import com.arabyte.arabyteapi.domain.auth.util.JwtAuthenticationFilter
+import com.arabyte.arabyteapi.domain.auth.util.JwtProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @EnableWebSecurity
 @Configuration
-class SecurityConfiguration {
+class SecurityConfiguration(
+    private val jwtProvider: JwtProvider
+) {
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .csrf { it.disable() }
             .authorizeHttpRequests {
-                it.anyRequest().permitAll()
+                it.requestMatchers("/auth/kakao/").permitAll()
             }
+            .addFilterBefore(
+                JwtAuthenticationFilter(jwtProvider),
+                UsernamePasswordAuthenticationFilter::class.java
+            )
             .formLogin { it.disable() }
             .httpBasic { it.disable() }
 


### PR DESCRIPTION
## 📚 개요

- it.anyRequest().authenticated() 구문을 추가하지 않아서 인증이 안됐던 오류를 해결했습니다.
- 이후 pr에서 토큰을 일괄적으로 해결할수 있는 resolver를 추가할 예정입니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- it.anyRequest().authenticated()는 모든 경로가 로그인이 된 상태로 요청을 보내야 한다는 의미입니다. 기존에는 로그인 + 특정 권한까지 요구하고 있었던 것을 로그인으로 낮춘것이라고 봐도 됩니다.