### PR TITLE
fix: 본인의 닉네임이 중복처리 되는 문제 해결

### DIFF
--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/user/controller/UserController.kt
@@ -35,8 +35,9 @@ class UserController(
     @Operation(summary = "닉네임 중복확인", description = "닉네임이 이미 존재하는지 확인합니다.")
     @GetMapping("/nickname/check")
     fun checkNickNameDuplicate(
+        @RequestUser user: User,
         @RequestParam nickname: String
     ): CheckNickNameResponse {
-        return userService.checkNickNameDuplicate(nickname)
+        return userService.checkNickNameDuplicate(nickname, user.id)
     }
 }

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/user/repository/UserRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<User, Long> {
     fun findByKakaoId(kakaoId: Long): User?
-    fun existsByNickname(nickname: String): Boolean
+    fun existsByNicknameAndIdNot(nickname: String, id: Long): Boolean
 }

--- a/src/main/kotlin/com/arabyte/arabyteapi/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/arabyte/arabyteapi/domain/user/service/UserService.kt
@@ -41,12 +41,8 @@ class UserService(
         )
     }
 
-    private fun isNicknameExists(nickname: String): Boolean {
-        return userRepository.existsByNickname(nickname)
-    }
-
-    fun checkNickNameDuplicate(nickname: String): CheckNickNameResponse {
-        val isDuplicate = isNicknameExists(nickname)
+    fun checkNickNameDuplicate(nickname: String, userId: Long): CheckNickNameResponse {
+        val isDuplicate = userRepository.existsByNicknameAndIdNot(nickname, userId)
 
         return CheckNickNameResponse(
             isDuplicate = isDuplicate,


### PR DESCRIPTION
## 📚 개요

- UserRepository의 기존 existsByNickname()를
existsByNicknameAndIdNot()로 수정하여 본인의 닉네임은 중복처리 되지 않도록 수정했습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

- UserRepository의 기존 `existsByNickname()`를
`existsByNicknameAndIdNot()`로 수정하여 본인의 닉네임은 중복처리 되지 않도록 수정했습니다.
- 중복처리를 위해서 UserId를 카카오 로그인 직후 발급받은 Access Token을 통해서 가져오도록 수정
- 쓸데없이 나누어진 중복체크 함수 삭제
 